### PR TITLE
Apply macOS fixes to Makefile

### DIFF
--- a/Apple_C/src/Makefile
+++ b/Apple_C/src/Makefile
@@ -45,8 +45,9 @@ clean:
 	rm -f zeroconf_lookup *.o
 
 install: zeroconf_lookup
-	install -v zeroconf_lookup $(DESTDIR)$(prefix)/bin
-	$(DESTDIR)$(prefix)/bin/zeroconf_lookup -i
+	mkdir -p "$(DESTDIR)$(prefix)/bin"
+	install -v zeroconf_lookup "$(DESTDIR)$(prefix)/bin/zeroconf_lookup"
+	"$(DESTDIR)$(prefix)/bin/zeroconf_lookup" -i
 
 uninstall: zeroconf_lookup
 	./zeroconf_lookup -u


### PR DESCRIPTION
I'm writing a Homebrew formula for this, but I run into the following problems:

1. Homebrew, at least, doesn't check that `$prefix` exists before building. Thus, it's better that the Makefile explicitly checks that the destination-directory exists as expected:

       install -v zeroconf_lookup /usr/local/Cellar/zeroconf-lookup/2.4.2/bin
       install: /usr/local/Cellar/zeroconf-lookup/2.4.2/bin: No such file or directory

2. At least on macOS/BSD, `install` installs *directly* into the given filename; not treating it as a directory. Thus, this error:

       install -v zeroconf_lookup /usr/local/Cellar/zeroconf-lookup/2.4.2/bin
       install: zeroconf_lookup -> /usr/local/Cellar/zeroconf-lookup/2.4.2/bin
       /usr/local/Cellar/zeroconf-lookup/2.4.2/bin/zeroconf_lookup -i
       make: /usr/local/Cellar/zeroconf-lookup/2.4.2/bin/zeroconf_lookup: No such file or directory

    (“No such file or directory”, because `/usr/local/Cellar/zeroconf-lookup/2.4.2/bin` is now a binary.)

Anyway, these changes make my Formula work — unfortunately, you may have to create a Tap for it, as Homebrew issued this helpful, explicit warning when I was writing this:

      * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)

Thaaaaanks, Homebrew. 🙄

----

Here's the Formula file, so far — it'll (obviously) need changing once you've pushed a new version with the attached fixes. If you need help making a Tap for it, I'm happy to do so for you — it's very little work.

```ruby
class ZeroconfLookup < Formula
  desc "Native server for WebExtensions that find local Zeroconf webservers"
  homepage "https://github.com/railduino/zeroconf-lookup"
  url "https://github.com/railduino/zeroconf-lookup/raw/master/Apple_C/zeroconf_lookup-2.4.2.tgz"
  sha256 "413cae721bae2a8f853c150cc8ad35b627d27bcd2f9a0b75c683a564858272f1"

  def install
    system "mkdir", "-p", prefix
    system "make", "prefix=#{prefix}", "install"
  end

  test do
    system "#{bin}/zeroconf_lookup", "--help"
  end
end
```